### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ npm install tslint-config-valorsoft
 ```js
 // tslint.json
 {
-  "extends": "./node_modules/tslint-config-valorsoft/tslint.json",
+  "extends": "tslint-config-valorsoft",
   "rulesDirectory": "./node_modules/codelyzer/dist/src"
 
   "rules": {


### PR DESCRIPTION
The `rulesDirectory` needs some thought.

@JKillian, do you have some idea? This use case is getting the `rulesDirectory` on a different package. It would break npm2/3+ as we know.

`codelyzer` should exposes its rulesDirectory nicely somehow.
I'm thinking in line of:

``` js
// codelyzer/dist/tslint.json
{
  "rulesDirectory": "./src"
}

// tslint-config-valorsoft/tslint.json
{
  "extends": "codelyzer/dist/tslint.json"
}
```
