### PR TITLE
chore(core): extend no-unnecessary-class

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -195,6 +195,6 @@
     "no-implicit-dependencies": true,
     "no-redundant-jsdoc":true,
     "no-return-await": true,
-    "no-unnecessary-class": true
+    "no-unnecessary-class": ["allow-empty-class", "allow-static-only"]
   }
 }


### PR DESCRIPTION
1) https://palantir.github.io/tslint/rules/no-unnecessary-class/
`"no-unnecessary-class"` extended, because of `export class XXXModule {}`

~~2) https://palantir.github.io/tslint/rules/no-implicit-dependencies/
`"no-implicit-dependencies": [true, "dev"]` - does not work properly with any parameter or even if move `devDependencies` to `dependencies`. So, should be disabled.~~   --->  **Resolved**

![](https://image.prntscr.com/image/ymaPs4D2TuWN2t6RwX_c7Q.png)