### PR TITLE
feat(core): add ban for fit, fdescribe, xit, xdescribe

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -38,7 +38,7 @@
     "unified-signatures": true,
 
     "await-promise": true,
-    "ban": false,
+    "ban": [true, ["fit"], ["fdescribe"], ["xit"], ["xdescribe"]],
     "curly": true,
     "forin": true,
     "import-blacklist": [true, "rxjs", "rxjs/Rx", "lodash"],

--- a/tslint.json
+++ b/tslint.json
@@ -38,7 +38,7 @@
     "unified-signatures": true,
 
     "await-promise": true,
-    "ban": [true, ["fit"], ["fdescribe"], ["xit"], ["xdescribe"]],
+    "ban": [true, "fit", "fdescribe", "xit", "xdescribe"],
     "curly": true,
     "forin": true,
     "import-blacklist": [true, "rxjs", "rxjs/Rx", "lodash"],


### PR DESCRIPTION
Updated rule `ban` to non-use `fit`, `fdescribe`, `xit`, `xdescribe`