### PR TITLE
feat(lint): remove deprecated rule typeof-compare

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -84,7 +84,6 @@
     "strict-type-predicates": false,
     "switch-default": true,
     "triple-equals": [true, "allow-null-check"],
-    "typeof-compare": true,
     "use-default-type-parameter": true,
     "use-isnan": true,
     "cyclomatic-complexity": true,


### PR DESCRIPTION
Starting from TypeScript 2.2 this rule is redundant
![1526462661583](https://user-images.githubusercontent.com/19388643/40108610-15b3165c-5904-11e8-9f5f-0596aa22c388.jpg)
